### PR TITLE
fix: resolved tailwind classes not giving css on build-time

### DIFF
--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -22,6 +22,7 @@
     "eslint": "^8",
     "eslint-config-next": "14.1.0",
     "postcss": "^8.4.33",
+    "postcss-import": "^16.0.0",
     "tailwindcss": "^3.4.1",
     "typescript": "^5"
   }

--- a/apps/learner/package.json
+++ b/apps/learner/package.json
@@ -22,6 +22,7 @@
     "eslint": "^8",
     "eslint-config-next": "14.1.0",
     "postcss": "^8.4.33",
+    "postcss-import": "^16.0.0",
     "tailwindcss": "^3.4.1",
     "typescript": "^5"
   }

--- a/packages/tailwind-config/postcss.config.js
+++ b/packages/tailwind-config/postcss.config.js
@@ -1,5 +1,6 @@
 module.exports = {
   plugins: {
+    'postcss-import': {},
     tailwindcss: {},
     autoprefixer: {},
   },

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -22,6 +22,7 @@
     "eslint": "^8.56.0",
     "learner": "^1.0.0",
     "postcss": "^8.4.33",
+    "postcss-import": "^16.0.0",
     "react": "^18.2.0",
     "tailwindcss": "^3.4.1",
     "typescript": "^5.3.3"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -60,6 +60,9 @@ importers:
       postcss:
         specifier: ^8.4.33
         version: 8.4.33
+      postcss-import:
+        specifier: ^16.0.0
+        version: 16.0.0(postcss@8.4.33)
       tailwindcss:
         specifier: ^3.4.1
         version: 3.4.1
@@ -103,6 +106,9 @@ importers:
       postcss:
         specifier: ^8.4.33
         version: 8.4.33
+      postcss-import:
+        specifier: ^16.0.0
+        version: 16.0.0(postcss@8.4.33)
       tailwindcss:
         specifier: ^3.4.1
         version: 3.4.1
@@ -180,6 +186,9 @@ importers:
       postcss:
         specifier: ^8.4.33
         version: 8.4.33
+      postcss-import:
+        specifier: ^16.0.0
+        version: 16.0.0(postcss@8.4.33)
       react:
         specifier: ^18.2.0
         version: 18.2.0
@@ -4380,6 +4389,18 @@ packages:
   /postcss-import@15.1.0(postcss@8.4.33):
     resolution: {integrity: sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==}
     engines: {node: '>=14.0.0'}
+    peerDependencies:
+      postcss: ^8.0.0
+    dependencies:
+      postcss: 8.4.33
+      postcss-value-parser: 4.2.0
+      read-cache: 1.0.0
+      resolve: 1.22.8
+    dev: true
+
+  /postcss-import@16.0.0(postcss@8.4.33):
+    resolution: {integrity: sha512-e77lhVvrD1I2y7dYmBv0k9ULTdArgEYZt97T4w6sFIU5uxIHvDFQlKgUUyY7v7Barj0Yf/zm5A4OquZN7jKm5Q==}
+    engines: {node: '>=18.0.0'}
     peerDependencies:
       postcss: ^8.0.0
     dependencies:


### PR DESCRIPTION
fix: added postcss-import to devDependency

<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. 
-->

## Summary

It seems there is a thing with tailwind 3 which caused the tailwind classes to apply on build on build time.

So I added the 'postcss-import' plugin as suggested by the tailwind team and now it should work as intended

<!--
 Explain the **motivation** of this Pull Request
-->

- [x] Tested (Must)
- [ ] Test Case added
- [x] Build Successful (Must)
- [x] Sufficient Code comments added (Must)
- [ ] Attached Screenshots / Videos <!-- if the PR contains UI changed, fixes, improvements -->
- [x] All Relevant Documents added


## Depends on

<!--- Does this PR depend on another PR that should be merged first or at the same time -->
