### PR TITLE
feat: add lucide-react package to project dependency to ui package

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -36,6 +36,7 @@
     "@radix-ui/react-slot": "^1.0.2",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.0",
+    "lucide-react": "^0.331.0",
     "tailwind-merge": "^2.2.1"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -168,6 +168,9 @@ importers:
       clsx:
         specifier: ^2.1.0
         version: 2.1.0
+      lucide-react:
+        specifier: ^0.331.0
+        version: 0.331.0(react@18.2.0)
       tailwind-merge:
         specifier: ^2.2.1
         version: 2.2.1
@@ -3922,6 +3925,14 @@ packages:
     resolution: {integrity: sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==}
     engines: {node: '>=12'}
     dev: true
+
+  /lucide-react@0.331.0(react@18.2.0):
+    resolution: {integrity: sha512-CHFJ0ve9vaZ7bB2VRAl27SlX1ELh6pfNC0jS96qGpPEEzLkLDGq4pDBFU8RhOoRMqsjXqTzLm9U6bZ1OcIHq7Q==}
+    peerDependencies:
+      react: ^16.5.1 || ^17.0.0 || ^18.0.0
+    dependencies:
+      react: 18.2.0
+    dev: false
 
   /make-error@1.3.6:
     resolution: {integrity: sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==}


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. 
-->

## Summary
The lucide-react package is added to the project dependencies to provide support for using Lucide icons in the application. This package is added with a version specifier of "^0.331.0" to ensure compatibility. Additionally, it has a peer dependency on react with a version specifier of "^16.5.1 || ^17.0.0 || ^18.0.0" and a dependency on react version 18.2.0.

<!--
 Explain the **motivation** of this Pull Request
-->

- [x] Tested (Must)
- [ ] Test Case added
- [x] Build Successful (Must)
- [x] Sufficient Code comments added (Must)
- [ ] Attached Screenshots / Videos <!-- if the PR contains UI changed, fixes, improvements -->
- [x] All Relevant Documents added


## Depends on

<!--- Does this PR depend on another PR that should be merged first or at the same time -->
