### PR TITLE
impr: add custom icons for Google and GitHub providers

### DIFF
--- a/packages/ui/src/components/authentication-provider-button/auth-provider-button.tsx
+++ b/packages/ui/src/components/authentication-provider-button/auth-provider-button.tsx
@@ -1,0 +1,40 @@
+import { GithubAuthIcon, GoogleAuthIcon } from "../../icons";
+import { Button, ButtonProps } from "../../partials/button";
+
+interface TAuthProviderButtonProps extends ButtonProps {
+  provider: "google" | "github";
+}
+
+interface ButtonData {
+  icon: React.ReactNode;
+  text: string;
+}
+
+export const AuthProviderButton = ({
+  provider,
+  ...props
+}: TAuthProviderButtonProps) => {
+  let buttonData: ButtonData;
+
+  switch (provider) {
+    case "google":
+      buttonData = {
+        icon: <GoogleAuthIcon className="h-5 w-5"/>,
+        text: "Google",
+      };
+      break;
+    case "github":
+      buttonData = {
+        icon: <GithubAuthIcon className="h-5 w-5"/>,
+        text: "GitHub",
+      };
+      break;
+  }
+
+  return (
+    <Button variant="provider" {...props}>
+      {buttonData.icon}
+      {buttonData.text}
+    </Button>
+  );
+};

--- a/packages/ui/src/components/index.ts
+++ b/packages/ui/src/components/index.ts
@@ -1,2 +1,3 @@
-export * from './auth-page/auth-page'
-export * from './application-layout/application-page'
+export * from "./auth-page/auth-page";
+export * from "./application-layout/application-page";
+export * from "./authentication-provider-button/auth-provider-button";

--- a/packages/ui/src/icons/github.tsx
+++ b/packages/ui/src/icons/github.tsx
@@ -1,16 +1,11 @@
-import { IconNode, createLucideIcon } from "lucide-react";
+import { IconNode, createLucideIcon, LucideProps } from "lucide-react";
 
 const GithubIconNode: IconNode = [
   [
-    "svg",
-    {
-      key: "svg-1",
-      viewBox: "0 0 20 20",
-    },
-  ],
-  [
     "path",
     {
+      "fill-rule": "evenodd",
+      "clip-rule": "evenodd",
       key: "path-1",
       fill: "#000000",
       d: "M10 0C4.477 0 0 4.484 0 10.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0110 4.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.203 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.942.359.31.678.921.678 1.856 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0020 10.017C20 4.484 15.522 0 10 0z",
@@ -18,4 +13,12 @@ const GithubIconNode: IconNode = [
   ],
 ];
 
-export const CustomGithubIcon = createLucideIcon("Github", GithubIconNode);
+const Icon = createLucideIcon("Github", GithubIconNode);
+
+export const GithubAuthIcon = ({ ...props }: LucideProps) => (
+  <Icon
+    viewBox="0 0 20 20"
+    stroke="transparent"
+    {...props}
+  />
+);

--- a/packages/ui/src/icons/google.tsx
+++ b/packages/ui/src/icons/google.tsx
@@ -1,13 +1,6 @@
-import { IconNode, createLucideIcon } from "lucide-react";
+import { IconNode, LucideProps, createLucideIcon } from "lucide-react";
 
 const GoogleIconNode: IconNode = [
-  [
-    "svg",
-    {
-      key: "svg-1",
-      viewBox: "0 0 24 24"
-    },
-  ],
   [
     "path",
     {
@@ -42,4 +35,8 @@ const GoogleIconNode: IconNode = [
   ],
 ];
 
-export const CustomGoogleIcon = createLucideIcon("Google", GoogleIconNode);
+const Icon = createLucideIcon("Google", GoogleIconNode);
+
+export const GoogleAuthIcon = ({ ...props }: LucideProps) => (
+  <Icon stroke="transparent" {...props} />
+);


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. 
-->

## Summary
- Added a new file `auth-provider-button.tsx` to handle rendering of provider buttons with custom icons for Google and GitHub.
- Created `GoogleAuthIcon` and `GithubAuthIcon` components that use the `createLucideIcon` function from `lucide-react` to render the respective icons.
- Added styling and props to customize the icons to adjust size and stroke color.

This change was made to improve the visual representation of the provider buttons and provide a consistent design across the application.

### Screenshot
![image](https://github.com/kalvilabs/kalvi/assets/58748190/405a0704-0436-4792-8079-c8307da2d853)

<!--
 Explain the **motivation** of this Pull Request
-->
### Checklist
- [x] Tested (Must)
- [ ] Test Case added
- [x] Build Successful (Must)
- [x] Sufficient Code comments added (Must)
- [x] Attached Screenshots / Videos <!-- if the PR contains UI changed, fixes, improvements -->
- [x] All Relevant Documents added


## Depends on

<!--- Does this PR depend on another PR that should be merged first or at the same time -->
