### PR TITLE
feat: implement reset password form with validation using zod schema

### DIFF
--- a/apps/admin/app/(auth)/reset-password/_components/form-schema.ts
+++ b/apps/admin/app/(auth)/reset-password/_components/form-schema.ts
@@ -1,0 +1,17 @@
+import { z } from "zod";
+
+export const formSchema = z.object({
+  email: z.string().email(),
+  password: z
+    .string({
+      required_error: "Password is required",
+    })
+    .min(8, { message: "Password must contain at least 8 character(s)" }),
+  confirmPassword: z
+    .string({
+      required_error: "Confirm Password is required",
+    })
+    .min(8, { message: "Password must contain at least 8 character(s)" }),
+});
+
+export type TFormSchema = z.infer<typeof formSchema>;

--- a/apps/admin/app/(auth)/reset-password/_components/form.tsx
+++ b/apps/admin/app/(auth)/reset-password/_components/form.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+import { AuthPage } from "@repo/ui/components";
+import { formSchema, TFormSchema } from "./form-schema";
+import { useForm } from "react-hook-form";
+import { ReactForm } from "@repo/ui/forms";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { Button, Input, Linktag } from "@repo/ui/partials";
+import Link from "next/link";
+
+
+export function ResetPasswordForm() {
+  const form = useForm<TFormSchema>({
+    resolver: zodResolver(formSchema),
+    defaultValues: {
+      email: "example@gmail.com",
+      password: "",
+      confirmPassword: "",
+    },
+  });
+
+  const onSubmit = () => {
+    console.log("Submitted");
+  };
+
+  return (
+    <>
+      <AuthPage.FormHeader
+        cardTitle="Reset Your Password"
+        cardDescriptionComponent={
+          <span>
+            Your new password must be different from previous used passwords.
+          </span>
+        }
+      />
+      <ReactForm.Form {...form}>
+        <AuthPage.FormWrapper onSubmit={form.handleSubmit(onSubmit)}>
+          <ReactForm.FormField
+            control={form.control}
+            name="email"
+            render={({ field }) => (
+              <ReactForm.FormItem>
+                <ReactForm.FormLabel>Email</ReactForm.FormLabel>
+                <ReactForm.FormControl>
+                  <Input type="email" disabled {...field} />
+                </ReactForm.FormControl>
+                <ReactForm.FormMessage />
+              </ReactForm.FormItem>
+            )}
+          />
+          <ReactForm.FormField
+            control={form.control}
+            name="password"
+            render={({ field }) => (
+              <ReactForm.FormItem>
+                <ReactForm.FormLabel>Password</ReactForm.FormLabel>
+                <ReactForm.FormControl>
+                  <Input type="password" {...field} />
+                </ReactForm.FormControl>
+                <ReactForm.FormMessage />
+              </ReactForm.FormItem>
+            )}
+          />
+          <ReactForm.FormField
+            control={form.control}
+            name="confirmPassword"
+            render={({ field }) => (
+              <ReactForm.FormItem>
+                <ReactForm.FormLabel>Confirm Password</ReactForm.FormLabel>
+                <ReactForm.FormControl>
+                  <Input type="password" {...field} />
+                </ReactForm.FormControl>
+                <ReactForm.FormMessage />
+              </ReactForm.FormItem>
+            )}
+          />
+          <AuthPage.FormFooter isMarginTop>
+            <Button type="submit">Reset Password</Button>
+            <Link href="/login" passHref legacyBehavior>
+              <Linktag textSize="sm">Back to Sign In</Linktag>
+            </Link>
+          </AuthPage.FormFooter>
+        </AuthPage.FormWrapper>
+      </ReactForm.Form>
+    </>
+  );
+}

--- a/apps/admin/app/(auth)/reset-password/page.tsx
+++ b/apps/admin/app/(auth)/reset-password/page.tsx
@@ -1,0 +1,12 @@
+import { Metadata } from "next";
+import { ResetPasswordForm } from "./_components/form";
+
+
+export const metadata: Metadata = {
+  title: "KalviOS | Reset Password",
+  description: "Reset Password",
+};
+
+export default function ResetPasswordPage() {
+  return <ResetPasswordForm />;
+}


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. 
-->

## Summary
The reset password form now includes validation using a zod schema for email, password, and confirm password fields. The form also includes default values and onSubmit functionality. Additionally, a metadata object is added for the Reset Password page with title and description.
<!--
 Explain the **motivation** of this Pull Request
-->
### Screenshots
![image](https://github.com/kalvilabs/kalvi/assets/58748190/26a2deb8-46f5-47ae-931b-b8e82bf96d50)
![image](https://github.com/kalvilabs/kalvi/assets/58748190/64b47748-4c75-4f28-8246-fe15c7f195de)


### Checklist
- [x] Tested (Must)
- [ ] Test Case added
- [x] Build Successful (Must)
- [x] Sufficient Code comments added (Must)
- [x] Attached Screenshots / Videos <!-- if the PR contains UI changed, fixes, improvements -->
- [x] All Relevant Documents added


## Depends on
#62 
<!--- Does this PR depend on another PR that should be merged first or at the same time -->
