### PR TITLE
feat: signout api integration

### DIFF
--- a/apps/admin/actions/cookie-destroy.ts
+++ b/apps/admin/actions/cookie-destroy.ts
@@ -1,10 +1,28 @@
-'use server';
+"use server";
 
+import { LOGOUT_URL } from "@/api-routes";
+import axios from "axios";
 import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
 
 export async function cookieDestroyer() {
-  cookies().delete("Authorization");
-  cookies().delete("Refresh");
-  redirect('/home');
+  try {
+    await axios.post(
+      LOGOUT_URL,
+      {
+        refresh_token: cookies().get("Refresh")?.value,
+      },
+      {
+        headers: {
+          Authorization: `Bearer ${cookies().get("Authorization")?.value}`,
+        },
+      }
+    );
+    cookies().delete("Authorization");
+    cookies().delete("Refresh");
+    redirect("/");
+  } catch (e) {
+    // TODO: Handle error with a popup or message and prevent signout to prevent the token from being live
+    console.error(e);
+  }
 }

--- a/apps/admin/actions/cookie-setter.ts
+++ b/apps/admin/actions/cookie-setter.ts
@@ -17,5 +17,5 @@ export async function cookieSetter({ access, refresh }: ILoginUserAction) {
     httpOnly: true,
     secure: true,
   });
-  redirect("/admin/dashboard")
+  redirect("/dashboard")
 }

--- a/apps/admin/api-routes/authentication.ts
+++ b/apps/admin/api-routes/authentication.ts
@@ -1,6 +1,7 @@
 import { BASE_URL } from "./base-url";
 
 export const LOGIN_URL = BASE_URL + "sign-in/";
+export const LOGOUT_URL = BASE_URL + "sign-out/";
 export const REGISTER_URL = BASE_URL + "sign-up/";
 export const FORGOT_PASSWORD_URL = BASE_URL + "send-reset-password-email/";
 export const RESET_PASSWORD_URL = (uid: string, token: string) =>


### PR DESCRIPTION
<!--
  Thanks for submitting a pull request!
  We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. 
-->

## Summary
Refactored the cookieDestroyer function to send a POST request to the LOGOUT_URL with the refresh token and authorization header.  Upon successful logout, the function now deletes the "Authorization" and "Refresh" cookies and redirects to "/home".

<!--
 Explain the **motivation** of this Pull Request
-->

- [x] Tested (Must)
- [ ] Test Case added
- [x] Build Successful (Must)
- [x] Sufficient Code comments added (Must)
- [ ] Attached Screenshots / Videos <!-- if the PR contains UI changed, fixes, improvements -->
- [x] All Relevant Documents added


## Depends on

<!--- Does this PR depend on another PR that should be merged first or at the same time -->
